### PR TITLE
Fix swerve max speed and joystick input value

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -21,7 +21,9 @@ public final class Constants {
     public static final double TRACKWIDTH = 29.5;
     public static final double WHEELBASE = 29.5;
 
-    public static final double SWERVE_MAX_VELOCITY = 80.0;
+    // https://www.swervedrivespecialties.com/products/mk3-swerve-module
+    // NEO Swerve max speed is 12.1ft/s, converted to about 3.6m/s
+    public static final double SWERVE_MAX_VELOCITY = 3.6; 
     public static final double SWERVE_MAX_ANGULAR_VELOCITY = 6*Math.PI;
     public static final double SWERVE_MAX_ANGULAR_ACCELERATION =  16*Math.PI;
 

--- a/src/main/java/frc/robot/commands/DriveCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCommand.java
@@ -49,7 +49,8 @@ public class DriveCommand extends CommandBase {
       right0 = 0;
     }
 
-    drivetrainSubsystem.drive(left0 * 3, left1 *3, -right0, false);  }
+    // Squaring controller inputs for finer control at low speeds
+    drivetrainSubsystem.drive(left0*left0, left1*left1, -right0, false);  }
 
   // Called once the command ends or is interrupted.
   @Override


### PR DESCRIPTION
@paulinejong2006 Hi its Jevon. I noticed the swerve max speed was originally 80, which translates to 80m/s, obviously unrealistic. The actual NEO Swerve motor's max speed is about 3.6m/s. Also, I used the square method to process inputs so the controls are more accurate at lower speeds. Please merge this in if it looks good.